### PR TITLE
Add Dockerfile for Nginx-based static app deployment in the k8s-integrate-docker folder

### DIFF
--- a/k8s-integrate-docker/Dockerfile
+++ b/k8s-integrate-docker/Dockerfile
@@ -1,4 +1,10 @@
 FROM nginx:alpine
-COPY index.html /usr/share/nginx/html/index.html
+
+# Set working directory
+WORKDIR /usr/share/nginx/html
+
+# Copy static files
+COPY index.html .
+
+# Expose port
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
This PR introduces a Dockerfile to containerize the application using `nginx:alpine`. It copies the static `index.html` into the container and exposes port 80 for access. This enables quick and consistent deployment.