### PR TITLE
fix: safe variable quoting, jq guard, and error handling in network-diagnostics.sh in the swarm folder

### DIFF
--- a/swarm/network-diagnostics.sh
+++ b/swarm/network-diagnostics.sh
@@ -1,45 +1,48 @@
 #!/bin/bash
+set -euo pipefail   # ← fail fast on errors / unset vars
+
+# Dependency check
+if ! command -v jq &>/dev/null; then
+  echo "Error: 'jq' is required but not installed." >&2
+  exit 1
+fi
+
+inspect_network() {
+  local net="$1"
+  if docker network inspect "$net" &>/dev/null; then
+    docker network inspect "$net" --format '{{json .}}' | jq '{
+      Name: .Name, Driver: .Driver, Scope: .Scope,
+      Subnet: .IPAM.Config[0].Subnet,
+      Gateway: .IPAM.Config[0].Gateway
+    }'
+  else
+    echo "  Network '$net' not found." >&2
+  fi
+}
 
 echo "=== Docker Swarm Network Diagnostics ==="
 
 echo "1. Swarm Status:"
 docker info | grep -A 5 "Swarm:"
 
-echo ""
-echo "2. Network List:"
+echo -e "\n2. Network List:"
 docker network ls
 
-echo ""
-echo "3. Service Status:"
+echo -e "\n3. Service Status:"
 docker service ls
 
-echo ""
-echo "4. Webapp Network Details:"
-docker network inspect webapp-network --format '{{json .}}' | jq '{
-  Name: .Name,
-  Driver: .Driver,
-  Scope: .Scope,
-  Subnet: .IPAM.Config[0].Subnet,
-  Gateway: .IPAM.Config[0].Gateway
-}'
+echo -e "\n4. Webapp Network Details:"
+inspect_network "webapp-network"
 
-echo ""
-echo "5. Backend Network Details:"
-docker network inspect backend-network --format '{{json .}}' | jq '{
-  Name: .Name,
-  Driver: .Driver,
-  Scope: .Scope,
-  Subnet: .IPAM.Config[0].Subnet,
-  Gateway: .IPAM.Config[0].Gateway
-}'
+echo -e "\n5. Backend Network Details:"
+inspect_network "backend-network"
 
-echo ""
-echo "6. Service VIP Info:"
-for service in $(docker service ls --format '{{.Name}}'); do
-    echo "Service: $service"
-    docker service inspect $service --format '{{range .Endpoint.VirtualIPs}}  Network: {{.NetworkID}} | IP: {{.Addr}}{{"\n"}}{{end}}'
-done
+echo -e "\n6. Service VIP Info:"
+while IFS= read -r service; do                           # ← quoted, safe loop
+  echo "Service: $service"
+  docker service inspect "$service" \
+    --format '{{range .Endpoint.VirtualIPs}}  Network: {{.NetworkID}} | IP: {{.Addr}}{{"\n"}}{{end}}'
+done < <(docker service ls --format '{{.Name}}')
 
-echo ""
-echo "7. Node Status:"
+echo -e "\n7. Node Status:"
 docker node ls


### PR DESCRIPTION
- Add `set -euo pipefail` to catch silent failures early
- Guard against missing `jq` with a preflight check
- Extract `inspect_network()` to handle missing networks gracefully
- Replace unquoted `for` loop with a quoted `while read` loop

No functional change to output — all existing sections preserved.