### PR TITLE
fix(conftest): configurable hub URL + auto-screenshot on failure

### DIFF
--- a/selenium-docker/conftest.py
+++ b/selenium-docker/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
@@ -10,11 +11,12 @@ def driver():
     chrome_options.add_argument("--disable-gpu")
     chrome_options.add_argument("--window-size=1920,1080")
 
+    hub_url = os.getenv("SELENIUM_HUB_URL", "http://localhost:4444/wd/hub")  # <-- fixed
+
     driver = webdriver.Remote(
-        command_executor='http://localhost:4444/wd/hub',
+        command_executor=hub_url,
         options=chrome_options
     )
-
     driver.implicitly_wait(10)
     yield driver
     driver.quit()
@@ -24,3 +26,11 @@ def pytest_runtest_makereport(item, call):
     outcome = yield
     rep = outcome.get_result()
     setattr(item, "rep_" + rep.when, rep)
+
+    # Auto-screenshot on failure                                               <-- fixed
+    if rep.when == "call" and rep.failed:
+        driver = item.funcargs.get("driver")
+        if driver:
+            os.makedirs("screenshots", exist_ok=True)
+            path = f"screenshots/{item.nodeid.replace('/', '_').replace('::', '_')}.png"
+            driver.save_screenshot(path)


### PR DESCRIPTION
**What changed:**

Hub URL now reads from `SELENIUM_HUB_URL` env var, falls back to `localhost:4444`
Failed tests auto-save a screenshot to `/screenshots/`