### PR TITLE
fix(monitor): add namespace/interval flags, trap, node metrics, color output

### DIFF
--- a/k8s-scaling/monitor-scaling.sh
+++ b/k8s-scaling/monitor-scaling.sh
@@ -1,18 +1,71 @@
 #!/bin/bash
-echo "=== Kubernetes Autoscaling Monitor ==="
-echo "Press Ctrl+C to stop"
+# =============================================================================
+# monitor-scaling.sh — Kubernetes Autoscaling Monitor
+# Usage: ./monitor-scaling.sh [-n <namespace>] [-i <interval_seconds>]
+# =============================================================================
+
+set -euo pipefail
+
+# ---------- defaults ----------
+NAMESPACE="default"
+INTERVAL=10
+
+# ---------- argument parsing ----------
+while getopts "n:i:h" opt; do
+  case $opt in
+    n) NAMESPACE="$OPTARG" ;;
+    i) INTERVAL="$OPTARG" ;;
+    h)
+      echo "Usage: $0 [-n namespace] [-i interval_seconds]"
+      echo "  -n  Kubernetes namespace to monitor (default: default)"
+      echo "  -i  Refresh interval in seconds    (default: 10)"
+      exit 0
+      ;;
+    *) echo "Unknown option: -$OPTARG" >&2; exit 1 ;;
+  esac
+done
+
+# ---------- color helpers ----------
+BOLD='\033[1m'
+CYAN='\033[0;36m'
+YELLOW='\033[0;33m'
+RESET='\033[0m'
+
+header() { echo -e "${CYAN}${BOLD}--- $1 ---${RESET}"; }
+
+# ---------- graceful exit ----------
+trap 'echo -e "\n${YELLOW}Monitor stopped at $(date). Namespace: ${NAMESPACE}${RESET}"; exit 0' INT TERM
+
+# ---------- main loop ----------
+echo -e "${BOLD}=== Kubernetes Autoscaling Monitor ===${RESET}"
+echo -e "Namespace: ${NAMESPACE} | Interval: ${INTERVAL}s | Press Ctrl+C to stop\n"
+
 while true; do
-    clear
-    echo "=== Time: $(date) ==="
-    echo
-    echo "--- HPA Status ---"
-    kubectl get hpa web-app-hpa
-    echo
-    echo "--- Pod Count ---"
-    kubectl get pods -l app=web-app -o wide
-    echo
-    echo "--- Resource Usage ---"
-    kubectl top pods -l app=web-app 2>/dev/null || echo "Metrics not ready yet..."
-    echo
-    sleep 10
+  clear
+  echo -e "${BOLD}=== Time: $(date) | Namespace: ${NAMESPACE} ===${RESET}"
+  echo
+
+  header "HPA Status"
+  kubectl get hpa web-app-hpa -n "$NAMESPACE" 2>&1 || echo "  HPA not found in namespace '${NAMESPACE}'"
+  echo
+
+  header "Deployment Rollout"
+  kubectl get deployment web-app -n "$NAMESPACE" 2>&1 || echo "  Deployment not found"
+  echo
+
+  header "Pod Count & Placement"
+  kubectl get pods -l app=web-app -n "$NAMESPACE" -o wide 2>&1 || echo "  No pods found"
+  echo
+
+  header "Pod Resource Usage"
+  TOP_OUT=$(kubectl top pods -l app=web-app -n "$NAMESPACE" 2>&1) \
+    && echo "$TOP_OUT" \
+    || echo "  Metrics unavailable — is metrics-server running? ($TOP_OUT)"
+  echo
+
+  header "Node Resource Usage"
+  kubectl top nodes 2>&1 || echo "  Node metrics unavailable"
+  echo
+
+  sleep "$INTERVAL"
 done


### PR DESCRIPTION
## Summary

Improves `monitor-scaling.sh` with production-ready features. No behavior
changes to existing defaults — fully backward compatible.

## Changes

| Area | Before | After |
|---|---|---|
| Namespace | hardcoded `default` | `-n <namespace>` flag |
| Refresh rate | hardcoded `10s` | `-i <seconds>` flag |
| Exit behavior | abrupt Ctrl+C | `trap` prints summary on exit |
| Deployment status | missing | `kubectl get deployment` block added |
| Node metrics | missing | `kubectl top nodes` block added |
| Error visibility | `2>/dev/null` hides errors | errors surfaced with context |
| Readability | plain text | ANSI color section headers |

## How to Test

```bash
# default namespace, 10s interval (same as before)
./monitor-scaling.sh

# custom namespace + faster refresh
./monitor-scaling.sh -n kube-system -i 5

# show help
./monitor-scaling.sh -h
```

## Checklist
- [x] Backward compatible (defaults unchanged)
- [x] Works on bash 3.x+ (macOS & Linux)
- [x] No new dependencies — pure `kubectl` + bash built-ins
- [x] `set -euo pipefail` added for safer scripting